### PR TITLE
ASC-408 Add flake8-pytest-mark

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+ignore = E501
+pytest_mark1 = name=test_id,value_match=uuid

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 molecule
 ansible
 flake8
+flake8-pytest-mark


### PR DESCRIPTION
This commit adds the requirement and configuration for the
flake8-pytest-mark plugin. This plugin ensures that tests are linted for
the presence of a UUID test_id value.