### PR TITLE
ASC-1039 Copy 'clouds.yaml' to Deployment Host

### DIFF
--- a/tasks/enable_api_access.yml
+++ b/tasks/enable_api_access.yml
@@ -1,0 +1,55 @@
+---
+# Task file for locating the 'clouds.yaml' file and placing it on the deployment host if necessary.
+
+- name: Register Utility Container
+  shell: |
+    lxc-ls -1 | grep utility | head -n 1
+  register: utility_container
+
+- name: Attempt to Locate '{{ os_clouds_yaml_path }}' on Utility Container
+  shell: |
+    lxc-attach -n "{{ utility_container.stdout }}" \
+    -- bash -c 'test -f "{{ os_clouds_yaml_path }}"'
+  register: utility_clouds_yaml_exists
+  ignore_errors: yes
+
+- name: Attempt to Locate '{{ os_clouds_yaml_path }}' on Infra1 Host
+  stat:
+    path: "{{ os_clouds_yaml_path }}"
+  register: infra1_clouds_yaml_exists
+  failed_when: utility_clouds_yaml_exists.rc == 1 and infra1_clouds_yaml_exists.stat.exists == False
+
+- name: Ensure '{{ os_config_path }}' Path Exists on Deployment Host
+  file:
+    path: "{{ os_config_path }}"
+    state: directory
+  delegate_to: localhost
+
+- name: Get '{{ os_clouds_yaml_path }}' from 'infra1' Host
+  block:
+    - name: Attempt to Extract '{{ os_clouds_yaml_path }}' Contents from 'infra1' Host
+      shell: |
+        cat "{{ os_clouds_yaml_path }}"
+      register: infra1_clouds_yaml_contents
+
+    - name: Copy '{{ os_clouds_yaml_path }}' from 'infra1' Host to Deployment Host
+      copy:
+        dest: "{{ os_clouds_yaml_path }}"
+        content: "{{ infra1_clouds_yaml_contents.stdout }}"
+      delegate_to: localhost
+  when: infra1_clouds_yaml_exists.stat.exists
+
+- name: Get '{{ os_clouds_yaml_path }}' from Utility Container
+  block:
+    - name: Attempt to Extract '{{ os_clouds_yaml_path }}' Contents from Utility Container
+      shell: |
+        lxc-attach -n "{{ utility_container.stdout }}" \
+        -- bash -c 'cat "{{ os_clouds_yaml_path }}"'
+      register: utility_clouds_yaml_contents
+
+    - name: Copy '{{ os_clouds_yaml_path }}' from Utility Container to Deployment Host
+      copy:
+        dest: "{{ os_clouds_yaml_path }}"
+        content: "{{ utility_clouds_yaml_contents.stdout }}"
+      delegate_to: localhost
+  when: utility_clouds_yaml_exists.rc == 0

--- a/tasks/enable_api_access.yml
+++ b/tasks/enable_api_access.yml
@@ -25,18 +25,11 @@
     state: directory
   delegate_to: localhost
 
-- name: Get '{{ os_clouds_yaml_path }}' from 'infra1' Host
-  block:
-    - name: Attempt to Extract '{{ os_clouds_yaml_path }}' Contents from 'infra1' Host
-      shell: |
-        cat "{{ os_clouds_yaml_path }}"
-      register: infra1_clouds_yaml_contents
-
-    - name: Copy '{{ os_clouds_yaml_path }}' from 'infra1' Host to Deployment Host
-      copy:
-        dest: "{{ os_clouds_yaml_path }}"
-        content: "{{ infra1_clouds_yaml_contents.stdout }}"
-      delegate_to: localhost
+- name: Copy '{{ os_clouds_yaml_path }}' from 'infra1' Host to Deployment Host
+  fetch:
+    src: "{{ os_clouds_yaml_path }}"
+    dest: "{{ os_clouds_yaml_path }}"
+    flat: yes
   when: infra1_clouds_yaml_exists.stat.exists
 
 - name: Get '{{ os_clouds_yaml_path }}' from Utility Container

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,6 +24,7 @@
       rpc_openstack['rpc_product_release'] is undefined
 
 - import_tasks: ssh_key_containers.yml
+- import_tasks: enable_api_access.yml
 
 - block:
     - import_tasks: cloning_openstack_ansible_ops.yml

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,7 @@
 ---
 # vars file for molecule-validate-glance-deploy
 public_key: "{{ lookup('file', '/root/.ssh/id_rsa.pub') }}"
+
+# vars for copying 'clouds.yaml' to the deployment host
+os_config_path: /root/.config/openstack
+os_clouds_yaml_path: "{{ os_config_path }}/clouds.yaml"


### PR DESCRIPTION
These Ansible tasks will locate the 'clouds.yaml' file on either the 'infra1'
host or utility container and copy the contents to the deployment host.

This will enable Molecule to utilize the Python OpenStack SDK without
resorting to exotic tricks to authenticate correctly.